### PR TITLE
add dictys GPU env for mdl.sh, add an parameter option

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -49,7 +49,7 @@ methods:
         min_target_genes: 10
     dictys:
         ext: 500000
-        device: 0
+        device: 'cuda:0'
         n_p2g_links: 20
 
 baselines: ['collectri', 'dorothea', 'random', 'scenic']

--- a/workflow/envs/dictys.yaml
+++ b/workflow/envs/dictys.yaml
@@ -4,6 +4,7 @@ channels:
   - pytorch
   - lingfeiwang
   - bioconda
+  - nvidia
 dependencies:
   - python=3.10
   - mamba
@@ -11,5 +12,5 @@ dependencies:
   - pytorch
   - torchvision
   - torchaudio
-  - cpuonly
+  - pytorch-cuda=11.7
   - mudata

--- a/workflow/rules/methods/dictys.smk
+++ b/workflow/rules/methods/dictys.smk
@@ -109,6 +109,8 @@ rule tfb_dictys:
     resources:
         mem_mb=restart_mem,
         runtime=config['max_mins_per_step'],
+    params:
+        use_p2g=True,
     shell:
         """
         set +e
@@ -121,7 +123,8 @@ rule tfb_dictys:
         --input_genome {input.genome} \
         --output_d {output.d} \
         --output_out {output.out} \
-        --threads {threads}
+        --threads {threads} \
+        --use_p2g {params.use_p2g} 
         if [ $? -eq 124 ]; then
             awk 'BEGIN {{ print "cre,tf,score" }}' > {output.out}
         fi
@@ -144,6 +147,7 @@ rule mdl_dictys:
     params:
         ext=config['methods']['dictys']['ext'] // 2,
         n_p2g_links=config['methods']['dictys']['n_p2g_links'],
+        device=config['method']['dictys']['device'],
     resources:
         mem_mb=restart_mem,
         runtime=config['max_mins_per_step'],
@@ -160,7 +164,8 @@ rule mdl_dictys:
         --distance {params.ext} \
         --n_p2g_links {params.n_p2g_links} \
         --threads {threads} \
-        --out_path {output.out}
+        --out_path {output.out} \
+        --device {params.device}
         if [ $? -eq 124 ]; then
             awk 'BEGIN {{ print "source,target,score,pval" }}' > {output.out}
         fi
@@ -187,6 +192,8 @@ rule mdl_o_dictys:
     params:
         ext=config['methods']['dictys']['ext'] // 2,
         n_p2g_links=config['methods']['dictys']['n_p2g_links'],
+        device=config['method']['dictys']['device'],
+        use_p2g=False,
     resources:
         mem_mb=restart_mem,
         runtime=config['max_mins_per_step'],
@@ -213,6 +220,7 @@ rule mdl_o_dictys:
         --input_genome {input.genome} \
         --output_d {output.d} \
         --output_out {output.tfb} \
+        --use_p2g {params.use_p2g} \
         --threads {threads} && \
         bash workflow/scripts/methods/dictys/mdl.sh \
         --output_d {output.d} \
@@ -223,6 +231,7 @@ rule mdl_o_dictys:
         --distance {params.ext} \
         --n_p2g_links {params.n_p2g_links} \
         --threads {threads} \
+        --device {params.device} \
         --out_path {output.out}'
         if [ $? -eq 124 ]; then
             awk 'BEGIN {{ print "cre,gene,score" }}' > {output.out}

--- a/workflow/scripts/methods/dictys/extract_data.py
+++ b/workflow/scripts/methods/dictys/extract_data.py
@@ -10,12 +10,14 @@ parser.add_argument('--pre_path', required=True)
 parser.add_argument('--p2g_path', required=True)
 parser.add_argument('--exp_path', required=True)
 parser.add_argument('--pks_path', required=True)
+parser.add_argument('--use_p2g' , required=True)
 
 args = vars(parser.parse_args())
 pre_path = args['pre_path']
 p2g_path = args['p2g_path']
 exp_path = args['exp_path']
 pks_path = args['pks_path']
+use_p2g  = args['use_p2g' ]
 
 
 # Write the RNA matrix
@@ -23,8 +25,13 @@ data = mu.read(pre_path)
 rna_X = pd.DataFrame(np.array(data['rna'].layers['counts'].todense()).T, columns=data['rna'].obs.index, index=data['rna'].var.index)
 rna_X.to_csv(exp_path, sep="\t", compression="gzip")
 
-# Read in p2g and keep only peaks that are wide enough for footprinting
-all_atac_peak = np.unique(pd.read_csv(p2g_path)['cre'])
+if use_p2g:
+    # Read in p2g and keep only peaks that are wide enough for footprinting
+    all_atac_peak = np.unique(pd.read_csv(p2g_path)['cre'])
+else:
+    # From the consensus peak list, keep only peaks that are wide enough for footprinting
+    all_atac_peak = np.unique([n.replace(':', '-') for n in data['atac'].var.index])
+
 all_atac_peak = pd.DataFrame([n.split('-') for n in all_atac_peak])
 all_atac_peak.columns = ['chr', 'srt', 'end']
 all_atac_peak['srt'] = all_atac_peak['srt'].astype(int)

--- a/workflow/scripts/methods/dictys/mdl.sh
+++ b/workflow/scripts/methods/dictys/mdl.sh
@@ -12,6 +12,7 @@ while [[ "$#" -gt 0 ]]; do
         --distance) distance="$2"; shift ;;
         --n_p2g_links) n_p2g_links="$2"; shift ;;
         --threads) threads="$2"; shift ;;
+        --device) device="$2"; shift ;;
         --out_path) out_path="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
@@ -36,7 +37,7 @@ $tfb_path $pre_path $output_d/peaks.tsv.gz $output_d/expr.tsv.gz $output_d/tfb.t
 python -m dictys chromatin tssdist --cut $distance $output_d/expr.tsv.gz $output_d/peaks.tsv.gz $annot $output_d/tssdist.tsv.gz && \
 python -m dictys chromatin linking $output_d/tfb.tsv.gz $output_d/tssdist.tsv.gz $output_d/linking.tsv.gz && \
 python -m dictys chromatin binlinking $output_d/linking.tsv.gz $output_d/binlinking.tsv.gz $n_p2g_links && \
-python -m dictys network reconstruct --nth $threads $output_d/expr.tsv.gz $output_d/binlinking.tsv.gz $output_d/net_weight.tsv.gz $output_d/net_meanvar.tsv.gz $output_d/net_covfactor.tsv.gz $output_d/net_loss.tsv.gz $output_d/net_stats.tsv.gz && \
+python -m dictys network reconstruct --device $device --nth $threads $output_d/expr.tsv.gz $output_d/binlinking.tsv.gz $output_d/net_weight.tsv.gz $output_d/net_meanvar.tsv.gz $output_d/net_covfactor.tsv.gz $output_d/net_loss.tsv.gz $output_d/net_stats.tsv.gz && \
 python -m dictys network normalize --nth $threads $output_d/net_weight.tsv.gz $output_d/net_meanvar.tsv.gz $output_d/net_covfactor.tsv.gz $output_d/net_nweight.tsv.gz && \
 python -c "import pandas as pd, numpy as np, sys, os; \
 weights = pd.read_csv(sys.argv[1], sep='\t', index_col=0); \

--- a/workflow/scripts/methods/dictys/pre.py
+++ b/workflow/scripts/methods/dictys/pre.py
@@ -31,11 +31,11 @@ rna_df = pd.read_csv(tmp_path, sep='\t', compression="gzip", index_col=0)
 genes, barcodes = rna_df.index.values.astype('U'), rna_df.columns.values.astype('U')
 rna = mdata.mod['rna']
 rna = rna[barcodes, :][:, genes].copy()
-rna.X = rna.layers['counts'].todense().copy()
+rna.X = rna.layers['counts'].todense().A.copy()
 
 # Process atac
 atac = mdata.mod['atac']
-atac.X = atac.layers['counts'].todense().copy()
+atac.X = atac.layers['counts'].todense().A.copy()
 
 # Update
 mdata.mod['rna'] = rna

--- a/workflow/scripts/methods/dictys/tfb.sh
+++ b/workflow/scripts/methods/dictys/tfb.sh
@@ -12,6 +12,7 @@ while [[ "$#" -gt 0 ]]; do
         --output_d) output_d="$2"; shift ;;
         --output_out) output_out="$2"; shift ;;
         --threads) threads="$2"; shift ;;
+        --use_p2g) use_p2g="$2"; shift ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
@@ -27,7 +28,8 @@ python workflow/scripts/methods/dictys/extract_data.py \
 --pre_path "$input_pre" \
 --p2g_path "$input_p2g" \
 --exp_path "$output_d/expr.tsv.gz" \
---pks_path "$output_d/peaks.bed" && \
+--pks_path "$output_d/peaks.bed" \
+--use_p2g "$use_p2g" && \
 for b_file in $output_d/barcodes_*; do
     ctype=$(basename "$b_file" | sed 's/barcodes_//; s/.txt//')
     bam_name="$output_d/reads_$ctype.bam"


### PR DESCRIPTION
1. tfb.sh now accepts a boolean parameter, use_p2g. This option is always set to True, except for mdl_o_dictys. When this option is set to False, rather than footprinting on peaks defined by p2g functions, Wellington will look at all peaks in the consensus peak list--all listed in data['atac'].var.index.
2. mdl.sh now accepts a parameter defined in the config.yaml, device. This option should be set to "cuda:0" to use GPU for the network inference. 